### PR TITLE
Removed dead external link from workflow section

### DIFF
--- a/index.md
+++ b/index.md
@@ -301,6 +301,7 @@ workflows.
 * [What git branching models actually work](http://stackoverflow.com/questions/2621610/what-git-branching-models-actually-work)
 * [Our New Git Branching Model](http://blogs.remobjects.com/blogs/mh/2011/08/25/p2940)
 * [Branch-per-Feature](http://dymitruk.com/blog/2012/02/05/branch-per-feature/)
+* [Who Needs Process](http://widgetsandshit.com/teddziuba/2011/12/process.html)
 
 However, also understand that everyone already has an implicit
 private branch due to their cloned repository: they can do work


### PR DESCRIPTION
Linked blog seems to be restarted around mid 2012 and old content is no longer available.
