### PR TITLE
Update link for Git from the Bottom Up

### DIFF
--- a/index.md
+++ b/index.md
@@ -42,7 +42,7 @@ recommended by various people as well.
 
 * [Pro Git](http://git-scm.com/book/)
 * [Git for Computer Scientists](http://eagain.net/articles/git-for-computer-scientists/) and a [different/updated version](http://sitaramc.github.com/gcs/)
-* [Git from the Bottom Up](http://ftp.newartisans.com/pub/git.from.bottom.up.pdf)
+* [Git from the Bottom Up](https://jwiegley.github.io/git-from-the-bottom-up/)
 * [The Git Parable](http://tom.preston-werner.com/2009/05/19/the-git-parable.html)
 * [Other resources](http://git-scm.com/documentation)
 * [Git wiki](http://git.wiki.kernel.org/)


### PR DESCRIPTION
The previous link was returning a 404, updated link to site